### PR TITLE
Add AccessControl for role management in SuperDCAGauge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- Integrated OpenZeppelin's AccessControl to manage roles, including a new MANAGER_ROLE.
- Implemented functions to set the mint rate and update the manager role, with appropriate access restrictions.
- Added tests to verify role-based access for mint rate updates and manager role changes.

Resolves: #4 